### PR TITLE
Install patch-package and provide fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "code-push-web",
             "version": "1.0.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "@reduxjs/toolkit": "2.2.3",
                 "bootstrap": "5.3.3",
@@ -41,6 +42,7 @@
                 "css-loader": "^6.10.0",
                 "eslint": "^9.29.0",
                 "isomorphic-style-loader": "^5.4.0",
+                "patch-package": "^8.0.0",
                 "pixrem": "^5.0.0",
                 "postcss": "^8.5.5",
                 "postcss-calc": "^10.1.1",
@@ -3736,6 +3738,13 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4041,6 +4050,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/autoprefixer": {
@@ -4698,6 +4717,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/classnames": {
@@ -6564,6 +6599,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "micromatch": "^4.0.2"
+            }
+        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -8070,10 +8115,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8099,6 +8171,16 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "license": "Public Domain",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8117,6 +8199,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/launch-editor": {
@@ -8777,6 +8869,16 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/own-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -8906,6 +9008,135 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/patch-package": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+            "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^9.0.0",
+                "json-stable-stringify": "^1.0.2",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.6",
+                "open": "^7.4.2",
+                "rimraf": "^2.6.3",
+                "semver": "^7.5.3",
+                "slash": "^2.0.0",
+                "tmp": "^0.0.33",
+                "yaml": "^2.2.2"
+            },
+            "bin": {
+                "patch-package": "index.js"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">5"
+            }
+        },
+        "node_modules/patch-package/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/patch-package/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/patch-package/node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package/node_modules/semver": {
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/patch-package/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/path-exists": {
@@ -10394,6 +10625,20 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
         "node_modules/router": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10964,6 +11209,16 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/socket.io": {
             "version": "4.8.1",
             "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
@@ -11496,6 +11751,19 @@
             "license": "MIT",
             "optional": true,
             "peer": true
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -12827,6 +13095,19 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "build": "ts-node -r tsconfig-paths/register scripts/build",
         "start": "ts-node -r tsconfig-paths/register scripts/runServer",
         "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
-        "clean": "npm dedupe"
+        "clean": "npm dedupe",
+        "postinstall": "patch-package"
     },
     "engines": {
         "node": ">=22.0.0",
@@ -54,6 +55,7 @@
         "css-loader": "^6.10.0",
         "eslint": "^9.29.0",
         "isomorphic-style-loader": "^5.4.0",
+        "patch-package": "^8.0.0",
         "pixrem": "^5.0.0",
         "postcss": "^8.5.5",
         "postcss-calc": "^10.1.1",

--- a/patches/http-proxy+1.18.1.patch
+++ b/patches/http-proxy+1.18.1.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/http-proxy/lib/http-proxy/common.js b/node_modules/http-proxy/lib/http-proxy/common.js
+index 6513e81..0555e80 100644
+--- a/node_modules/http-proxy/lib/http-proxy/common.js
++++ b/node_modules/http-proxy/lib/http-proxy/common.js
+@@ -1,6 +1,6 @@
+ var common   = exports,
+     url      = require('url'),
+-    extend   = require('util')._extend,
++    extend   = Object.assign,
+     required = require('requires-port');
+ 
+ var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
+diff --git a/node_modules/http-proxy/lib/http-proxy/index.js b/node_modules/http-proxy/lib/http-proxy/index.js
+index 977a4b3..739409c 100644
+--- a/node_modules/http-proxy/lib/http-proxy/index.js
++++ b/node_modules/http-proxy/lib/http-proxy/index.js
+@@ -1,5 +1,5 @@
+ var httpProxy = module.exports,
+-    extend    = require('util')._extend,
++    extend    = Object.assign,
+     parse_url = require('url').parse,
+     EE3       = require('eventemitter3'),
+     http      = require('http'),

--- a/patches/spdy+4.0.2.patch
+++ b/patches/spdy+4.0.2.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/spdy/lib/spdy/agent.js b/node_modules/spdy/lib/spdy/agent.js
+index 4adc524..b7a383d 100644
+--- a/node_modules/spdy/lib/spdy/agent.js
++++ b/node_modules/spdy/lib/spdy/agent.js
+@@ -11,7 +11,7 @@ var debug = require('debug')('spdy:client')
+ // Node.js 0.10 and 0.12 support
+ Object.assign = process.versions.modules >= 46
+   ? Object.assign // eslint-disable-next-line
+-  : util._extend
++  : Object.assign
+ 
+ var EventEmitter = require('events').EventEmitter
+ 
+diff --git a/node_modules/spdy/lib/spdy/server.js b/node_modules/spdy/lib/spdy/server.js
+index 1889fcd..0306dcf 100644
+--- a/node_modules/spdy/lib/spdy/server.js
++++ b/node_modules/spdy/lib/spdy/server.js
+@@ -14,7 +14,7 @@ var EventEmitter = require('events').EventEmitter
+ // Node.js 0.8, 0.10 and 0.12 support
+ Object.assign = process.versions.modules >= 46
+   ? Object.assign // eslint-disable-next-line
+-  : util._extend
++  : Object.assign
+ 
+ var spdy = require('../spdy')
+ 

--- a/patches/spdy-transport+3.0.0.patch
+++ b/patches/spdy-transport+3.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/spdy-transport/lib/spdy-transport/utils.js b/node_modules/spdy-transport/lib/spdy-transport/utils.js
+index 7f379f2..1f061cc 100644
+--- a/node_modules/spdy-transport/lib/spdy-transport/utils.js
++++ b/node_modules/spdy-transport/lib/spdy-transport/utils.js
+@@ -6,7 +6,7 @@ var isNode = require('detect-node')
+ // Node.js 0.8, 0.10 and 0.12 support
+ Object.assign = (process.versions.modules >= 46 || !isNode)
+   ? Object.assign // eslint-disable-next-line
+-  : util._extend
++  : Object.assign
+ 
+ function QueueItem () {
+   this.prev = null


### PR DESCRIPTION
## Summary
- add postinstall script for patch-package
- add patch-package dev dependency
- replace deprecated `util._extend` in http-proxy, spdy and spdy-transport using patch-package

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685bc3e4636483249303cc3dae769dbc